### PR TITLE
Implement Read timeout when reading from Mountpoints

### DIFF
--- a/pkgs/ntrip/caster/caster.go
+++ b/pkgs/ntrip/caster/caster.go
@@ -5,6 +5,7 @@ import (
     log "github.com/sirupsen/logrus"
     "github.com/satori/go.uuid"
     "fmt"
+    "time"
 )
 
 var (
@@ -14,8 +15,13 @@ var (
 
 func Serve(auth Authenticator) { // TODO: Serve should take a Config object of some description
     log.SetFormatter(&log.JSONFormatter{})
+    srv := &http.Server{
+        Addr: ":2101",
+        ReadTimeout: 5 * time.Second,
+        WriteTimeout: 10 * time.Second,
+    }
     http.HandleFunc("/", RequestHandler)
-    log.Fatal(http.ListenAndServe(":2101", nil))
+    log.Fatal(srv.ListenAndServe())
 }
 
 func RequestHandler(w http.ResponseWriter, r *http.Request) {

--- a/pkgs/ntrip/caster/caster.go
+++ b/pkgs/ntrip/caster/caster.go
@@ -5,7 +5,6 @@ import (
     log "github.com/sirupsen/logrus"
     "github.com/satori/go.uuid"
     "fmt"
-    "time"
 )
 
 var (
@@ -15,13 +14,8 @@ var (
 
 func Serve(auth Authenticator) { // TODO: Serve should take a Config object of some description
     log.SetFormatter(&log.JSONFormatter{})
-    srv := &http.Server{
-        Addr: ":2101",
-        ReadTimeout: 5 * time.Second,
-        WriteTimeout: 10 * time.Second,
-    }
     http.HandleFunc("/", RequestHandler)
-    log.Fatal(srv.ListenAndServe())
+    log.Fatal(http.ListenAndServe(":2101", nil))
 }
 
 func RequestHandler(w http.ResponseWriter, r *http.Request) {

--- a/pkgs/ntrip/caster/types.go
+++ b/pkgs/ntrip/caster/types.go
@@ -78,7 +78,6 @@ func (mount *Mountpoint) Broadcast() { // Read data from Source.Channel and writ
             mount.RUnlock()
 
         case <-time.After(time.Second * 5):
-            mount.Source.Request.Body.Close()
             return
 
         case <-mount.Source.Request.Context().Done():

--- a/pkgs/ntrip/caster/types.go
+++ b/pkgs/ntrip/caster/types.go
@@ -4,6 +4,7 @@ import (
     "errors"
     "sync"
     "net/http"
+    "time"
 )
 
 type Authenticator interface {
@@ -60,6 +61,7 @@ func (mount *Mountpoint) ReadSourceData() { // Read data from Request Body and w
     }
 }
 
+//TODO: Return error
 func (mount *Mountpoint) Broadcast() { // Read data from Source.Channel and write to registered subscriber channels
     for {
         select {
@@ -74,6 +76,10 @@ func (mount *Mountpoint) Broadcast() { // Read data from Source.Channel and writ
                 }
             }
             mount.RUnlock()
+
+        case <-time.After(time.Second * 5):
+            mount.Source.Request.Body.Close()
+            return
 
         case <-mount.Source.Request.Context().Done():
             return


### PR DESCRIPTION
I initially was explicitly closing the Request.Body when the time.After case occurred in Broadcast, however this could block indefinitely. Now I'm just returning and letting the defer statement close the body. I'm not sure if that statement is actually blocking forever in some cases - presumably that means there's a thread sitting around doing nothing, but I'm not sure if that will eventually time out, or if it's even a problem.