### PR TITLE
Proposed Cognito Auth Flow 

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,15 @@ go install ./...
 go get github.com/umeat/go-ntrip/...
 ```
 
+#### Run a Caster 
 Application in `cmd/ntripcaster/` configurable with `cmd/ntripcaster/caster.conf`.
+
+```
+# Generate self signed certs for testing
+openssl genrsa -out server.key 2048
+openssl req -new -x509 -sha256 -key server.key -out server.crt -days 3650
+
+ntripcaster &
+curl https://localhost:2102/mount -d "TEST" -i -k -u username:password &
+curl http://localhost:2101/mount -i
+```


### PR DESCRIPTION
All GET requests are allowed unauthenticated (with potential for adding a configurable list of mounts which require auth on GET).

All POST requests must be authenticated, and will be authorized if the Cognito user is in a group named `mount:PATH` where PATH is the path to which the POST request was issued (i.e. the mountpoint name).

I don't currently see a need to restrict POST requests to HTTPS only (although we will obviously be doing that heuristically, and ultimately presumably also source address blocking for POST requests). Once the caster has received the request over HTTP it's kind of too late for us to care (the credentials have already been sent in plain text) - except in the case where we want to have "Closed" streams which clients need authorization to access (as mentioned before w/ GET requests). In that case it is actually important that the data is encrypted, not just that the credentials are secure.